### PR TITLE
Upgraded fluent-hc to 4.3.4 due to bug

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -94,7 +94,7 @@
         <dependency>
             <groupId>org.apache.httpcomponents</groupId>
             <artifactId>fluent-hc</artifactId>
-            <version>4.3.3</version>
+            <version>4.3.4</version>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>

--- a/src/main/java/com/yammer/metrics/reporting/HttpTransport.java
+++ b/src/main/java/com/yammer/metrics/reporting/HttpTransport.java
@@ -1,7 +1,5 @@
 package com.yammer.metrics.reporting;
 
-import org.apache.http.client.methods.HttpPost;
-import org.apache.http.entity.ByteArrayEntity;
 import org.apache.http.entity.ContentType;
 
 import java.io.ByteArrayOutputStream;
@@ -21,12 +19,10 @@ public class HttpTransport implements Transport {
 
     public static class HttpRequest implements Transport.Request {
         private final HttpTransport transport;
-        private final HttpPost request;
         private final ByteArrayOutputStream out;
 
         public HttpRequest(HttpTransport transport) throws IOException {
             this.transport = transport;
-            this.request = new HttpPost(this.transport.seriesUrl);
             this.out = new ByteArrayOutputStream();
         }
 
@@ -37,10 +33,10 @@ public class HttpTransport implements Transport {
         public void send() throws Exception {
             this.out.flush();
             this.out.close();
-            this.request.setEntity(new ByteArrayEntity(out.toByteArray(), ContentType.APPLICATION_JSON));
 
             org.apache.http.client.fluent.Request.Post(this.transport.seriesUrl)
-                    .addHeader("Content-Type", "application/json")
+                    .addHeader("Content-Type",
+                               ContentType.APPLICATION_JSON.toString())
                     .bodyByteArray(this.out.toByteArray())
                     .execute();
         }


### PR DESCRIPTION
There seems to be a bug introduced by merging the last pull request that moved to `fluent-hc`. Submitting my fix.

This bug (https://issues.apache.org/jira/browse/HTTPCLIENT-1474) causes
an error to occur when POSTing to datadog using fluent static
Request.Post() method.
Removed unnecessary HttpPost field from HttpTransport
