### PR TITLE
Upgrading to metrics-3.1.1

### DIFF
--- a/dropwizard-metrics-datadog/pom.xml
+++ b/dropwizard-metrics-datadog/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>metrics-datadog-parent</artifactId>
         <groupId>org.coursera</groupId>
-        <version>1.0.7-SNAPSHOT</version>
+        <version>1.1.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/metrics-datadog/pom.xml
+++ b/metrics-datadog/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.coursera</groupId>
         <artifactId>metrics-datadog-parent</artifactId>
-        <version>1.0.7-SNAPSHOT</version>
+        <version>1.1.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
@@ -15,7 +15,7 @@
 
     <dependencies>
         <dependency>
-            <groupId>com.codahale.metrics</groupId>
+            <groupId>io.dropwizard.metrics</groupId>
             <artifactId>metrics-core</artifactId>
             <scope>compile</scope>
         </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.coursera</groupId>
     <artifactId>metrics-datadog-parent</artifactId>
-    <version>1.0.7-SNAPSHOT</version>
+    <version>1.1.0-SNAPSHOT</version>
     <packaging>pom</packaging>
     <name>Datadog Metrics Parent</name>
     <url>https://github.com/coursera/metrics-datadog</url>
@@ -54,9 +54,9 @@
         </contributor>
     </contributors>
     <properties>
-        <metrics.version>3.0.2</metrics.version>
+        <metrics.version>3.1.1</metrics.version>
         <jackson.version>2.2.2</jackson.version>
-        <dropwizard.version>0.7.1</dropwizard.version>
+        <dropwizard.version>0.8.1</dropwizard.version>
     </properties>
     <build>
         <plugins>
@@ -131,7 +131,7 @@
     <dependencyManagement>
         <dependencies>
             <dependency>
-                <groupId>com.codahale.metrics</groupId>
+                <groupId>io.dropwizard.metrics</groupId>
                 <artifactId>metrics-core</artifactId>
                 <version>${metrics.version}</version>
                 <type>jar</type>


### PR DESCRIPTION
@tianx2 Can you take a look at this? Figured it's time to upgrade to `metrics-3.1.1`, but wanted to get your take on the dropwizard support. We're currently at dropwizard 0.7.1. I haven't had a chance dig in and analyze dependencies, but one concern I had is that if dropwizard depends on `com.codahale.metrics` and metrics-datadog depends on `io.dropwizard.metrics`, both may be present on the classpath (they both use the same Java package names).  Haven't thought deeply about this, but just wanted to raise it for you to consider.

CC @torbjornvatn 