### PR TITLE
Metrics Counters are Datadog Gauges

### DIFF
--- a/metrics-datadog/src/main/java/org/coursera/metrics/datadog/DatadogReporter.java
+++ b/metrics-datadog/src/main/java/org/coursera/metrics/datadog/DatadogReporter.java
@@ -192,7 +192,13 @@ public class DatadogReporter extends ScheduledReporter {
 
   private void reportCounter(String name, Counter counter, long timestamp, List<String> tags)
       throws IOException {
-    request.addCounter(new DatadogCounter(name, counter.getCount(), timestamp, host, tags));
+    // A Metrics counter is actually a Datadog Gauge.  Datadog Counters are for rates which is
+    // similar to the Metrics Meter type.  Metrics counters have increment and decrement
+    // functionality, which implies they are instantaneously measurable, which implies they are
+    // actually a gauge. The Metrics documentation agrees, stating:
+    // "A counter is just a gauge for an AtomicLong instance. You can increment or decrement its
+    // value. For example, we may want a more efficient way of measuring the pending job in a queue"
+    request.addGauge(new DatadogGauge(name, counter.getCount(), timestamp, host, tags));
   }
 
   private void reportGauge(String name, Gauge gauge, long timestamp, List<String> tags)

--- a/metrics-datadog/src/test/java/org/coursera/metrics/datadog/DatadogReporterTest.java
+++ b/metrics-datadog/src/test/java/org/coursera/metrics/datadog/DatadogReporterTest.java
@@ -166,7 +166,7 @@ public class DatadogReporterTest {
 
     final InOrder inOrder = inOrder(transport, request);
     inOrder.verify(transport).prepare();
-    inOrder.verify(request).addCounter(new DatadogCounter("counter", 100L, timestamp, HOST, tags));
+    inOrder.verify(request).addGauge(new DatadogGauge("counter", 100L, timestamp, HOST, tags));
     inOrder.verify(request).send();
 
     verify(transport).prepare();
@@ -322,8 +322,8 @@ public class DatadogReporterTest {
             this.<Meter>map(),
             this.<Timer>map());
 
-    verify(request).addCounter(new DatadogCounter("testprefix.counter", 100L, timestamp, HOST, tags));
-    verify(request, never()).addCounter(new DatadogCounter("counter", 100L, timestamp, HOST, tags));
+    verify(request).addGauge(new DatadogGauge("testprefix.counter", 100L, timestamp, HOST, tags));
+    verify(request, never()).addGauge(new DatadogGauge("counter", 100L, timestamp, HOST, tags));
   }
 
   @Test
@@ -343,7 +343,7 @@ public class DatadogReporterTest {
             this.<Meter>map(),
             this.<Timer>map());
 
-    verify(request).addCounter(new DatadogCounter("counter", 100L, timestamp, HOST, dynamicTags));
+    verify(request).addGauge(new DatadogGauge("counter", 100L, timestamp, HOST, dynamicTags));
   }
 
   @Test
@@ -367,12 +367,12 @@ public class DatadogReporterTest {
 
     final InOrder inOrder = inOrder(transport, request);
     inOrder.verify(transport).prepare();
-    inOrder.verify(request).addCounter(new DatadogCounter("my.metric.counter",
+    inOrder.verify(request).addGauge(new DatadogGauge("my.metric.counter",
         123L,
         timestamp,
         HOST,
         tags));
-    inOrder.verify(request, never()).addCounter(new DatadogCounter("counter",
+    inOrder.verify(request, never()).addGauge(new DatadogGauge("counter",
         123L,
         timestamp,
         HOST,


### PR DESCRIPTION
I believe Codahale Metrics' Counter should be mapped to a DataDog Gauge metric, not a DataDog Counter.  Today it is a DataDog Counter as per:
https://github.com/coursera/metrics-datadog/blob/master/metrics-datadog/src/main/java/org/coursera/metrics/datadog/DatadogReporter.java#L195

The documentation in the Metrics library states (https://dropwizard.github.io/metrics/3.1.0/getting-started/#gauges):

>A counter is just a gauge for an AtomicLong instance. You can increment or decrement its value. For example, we may want a more efficient way of measuring the pending job in a queue

And the datadog documentation states:
http://docs.datadoghq.com/api/
>The type of the metric - gauge or counter (counter data is expected as a rate). Gauges are 32bit floats while counters are 64bit integers.

http://docs.datadoghq.com/guides/metrics/#counters
>... StatsD counters are normalized over the flush interval to report per-second units. ... To increment or measure values over time, please see gauges

http://docs.datadoghq.com/guides/metrics/#gauges
>Gauges measure the value of a particular thing over time.

These suggest different meanings of the word "counter" between the Datadog and Metrics implementations, which appears to have been overlooked in the Coursera Metrics/Datadog adapter.  Datadog Counter behaves more like the Metrics Meter (which is properly mapped), dealing with rates of change or rates of occurrence.  Metrics Counter acts more like a Datadog Guage, providing a specific value at a specific time.

The confusion is causing all of our counters (which are used to track queue sizes just like the metrics docs suggest) to provide completely useless information, since Datadog does work to measure the rate of change instead of absolute values.

The workaround we are using for now is to register a separate Gauge that reports the counter.getCount() as its value.  Something like:
```
        inFlight = metricRegistry.counter(name(SomeClass.class, "queue-size"));
        metricRegistry.register(name(SomeClass.class, "queue-size-gauge"), new Gauge<Long>() {
            @Override
            public Long getValue() {
                return inFlight.getCount();
            }
        });
```

Having the Datadog Gauge and Counter values side by side like this, we're easily able to prove that Gauge is the right thing for this application.