### PR TITLE
Fixing metric name for metrics with no tags (i.e. removing unnecessar…

### DIFF
--- a/metrics-datadog/src/main/java/org/coursera/metrics/datadog/TaggedName.java
+++ b/metrics-datadog/src/main/java/org/coursera/metrics/datadog/TaggedName.java
@@ -30,18 +30,20 @@ public class TaggedName {
   }
 
   public String encode() {
-    StringBuilder sb = new StringBuilder(this.metricName);
-    sb.append('[');
-    String prefix = "";
-    for (String encodedTag : encodedTags) {
-      sb.append(prefix);
-      sb.append(encodedTag);
-      prefix = ",";
+    if (!encodedTags.isEmpty()) {
+      StringBuilder sb = new StringBuilder(this.metricName);
+      sb.append('[');
+      String prefix = "";
+      for (String encodedTag : encodedTags) {
+        sb.append(prefix);
+        sb.append(encodedTag);
+        prefix = ",";
+      }
+      sb.append(']');
+      return sb.toString();
+    } else {
+      return this.metricName;
     }
-    sb.append(']');
-
-    return sb.toString();
-
   }
 
   public static TaggedName decode(String encodedTaggedName) {

--- a/metrics-datadog/src/test/java/org/coursera/metrics/datadog/TaggedNameTest.java
+++ b/metrics-datadog/src/test/java/org/coursera/metrics/datadog/TaggedNameTest.java
@@ -16,6 +16,7 @@ public class TaggedNameTest {
 
     assertEquals("metric", taggedName.getMetricName());
     assertEquals(0, taggedName.getEncodedTags().size());
+    assertEquals("metric", taggedName.encode());
   }
 
   @Test


### PR DESCRIPTION
…y brackets.)

Otherwise, a metric with no tags will have its name suffixed by `[]`.

`decode` falls back to using the raw value if no brackets are found, so I think this should be fine (even though there are no test cases - sorry, can't do them right now).