### PR TITLE
Added logging exception handler

### DIFF
--- a/metrics-datadog/src/main/java/org/coursera/metrics/datadog/transport/UdpTransport.java
+++ b/metrics-datadog/src/main/java/org/coursera/metrics/datadog/transport/UdpTransport.java
@@ -2,6 +2,7 @@ package org.coursera.metrics.datadog.transport;
 
 import com.timgroup.statsd.NonBlockingStatsDClient;
 import com.timgroup.statsd.StatsDClient;
+import com.timgroup.statsd.StatsDClientErrorHandler;
 import org.coursera.metrics.datadog.model.DatadogCounter;
 import org.coursera.metrics.datadog.model.DatadogGauge;
 import org.slf4j.Logger;
@@ -28,10 +29,15 @@ public class UdpTransport implements Transport {
 
   private UdpTransport(String prefix, String statsdHost, int port, String[] globalTags) {
     statsd = new NonBlockingStatsDClient(
-        prefix,
-        statsdHost,
-        port,
-        globalTags
+            prefix,
+            statsdHost,
+            port,
+            globalTags,
+            new StatsDClientErrorHandler() {
+              public void handle(Exception e) {
+                LOG.error(e.getMessage(),e);
+              }
+            }
     );
   }
 


### PR DESCRIPTION
We are in the process of changing the StatsD client to not cache DNS address resolutions forever. As a result of that, the hostname is not resolved during construction of the client, rather when data is pushed, thus we would like to get visibility of when hostname resolutions fail (see [this pr](https://github.com/indeedeng/java-dogstatsd-client/pull/26) ).  