### PR TITLE
Use `metricNameFormatter` when reporting gauges and counters as well

### DIFF
--- a/metrics-datadog/src/main/java/org/coursera/metrics/datadog/DatadogReporter.java
+++ b/metrics-datadog/src/main/java/org/coursera/metrics/datadog/DatadogReporter.java
@@ -197,14 +197,16 @@ public class DatadogReporter extends ScheduledReporter {
     // actually a gauge. The Metrics documentation agrees, stating:
     // "A counter is just a gauge for an AtomicLong instance. You can increment or decrement its
     // value. For example, we may want a more efficient way of measuring the pending job in a queue"
-    request.addGauge(new DatadogGauge(name, counter.getCount(), timestamp, host, tags));
+    request.addGauge(new DatadogGauge(metricNameFormatter.format(name), counter.getCount(),
+        timestamp, host, tags));
   }
 
   private void reportGauge(String name, Gauge gauge, long timestamp, List<String> tags)
       throws IOException {
     final Number value = toNumber(gauge.getValue());
     if (value != null) {
-      request.addGauge(new DatadogGauge(name, value, timestamp, host, tags));
+      request.addGauge(new DatadogGauge(metricNameFormatter.format(name), value, timestamp, host,
+          tags));
     }
   }
 


### PR DESCRIPTION
`metricNameFormatter` is only used by the `DatadogReporter.appendExpansionSuffix` private method. Because `DatadogReporter.reportGauge` and `DatadogReporter.reportCounters` don't require expansions, they don't call `DatadogReporter.appendExpansionSuffix` and, therefore, `metricNameFormatter` is ignored for them. This PR fixes it.

This is important for cases in which `metricNameFormatter` is used to intercept metrics that we don't control. For example, when using `DatadogReporter` with Spark metrics, I want to be able to capture some of its metrics in order to extract a few properties and make them tags. Since I don't control the metrics, I can't do it in the point where they are produced.