### PR TITLE
Drop port range check from UdpTransportFactory

### DIFF
--- a/dropwizard-metrics-datadog/src/main/java/org/coursera/metrics/datadog/transport/UdpTransportFactory.java
+++ b/dropwizard-metrics-datadog/src/main/java/org/coursera/metrics/datadog/transport/UdpTransportFactory.java
@@ -2,7 +2,6 @@ package org.coursera.metrics.datadog.transport;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonTypeName;
-import org.hibernate.validator.constraints.Range;
 
 import javax.validation.constraints.NotNull;
 
@@ -14,7 +13,6 @@ public class UdpTransportFactory implements AbstractTransportFactory {
   private String statsdHost = "localhost";
 
   @JsonProperty
-  @Range(min = 1, max = 49151)
   private int port = 8125;
 
   @JsonProperty


### PR DESCRIPTION
This range varies by platform, and enforcing use of a registered range makes it very hard to test. Many platforms allow you to start an agent on an available, unregistered port, by specifying port 0.

Also removes the only hibernate dependency in the project.