### PR TITLE
Fix decoding of tagged metric names with hyphens

### DIFF
--- a/metrics-datadog/src/main/java/org/coursera/metrics/datadog/TaggedName.java
+++ b/metrics-datadog/src/main/java/org/coursera/metrics/datadog/TaggedName.java
@@ -11,7 +11,7 @@ import java.util.regex.Pattern;
 
 public class TaggedName {
   private static final Pattern tagPattern = Pattern
-      .compile("([\\w\\.]+)\\[([\\w\\W]+)\\]");
+      .compile("([\\w\\.-]+)\\[([\\w\\W]+)\\]");
 
   private final String metricName;
   private final List<String> encodedTags;

--- a/metrics-datadog/src/test/java/org/coursera/metrics/datadog/TaggedNameTest.java
+++ b/metrics-datadog/src/test/java/org/coursera/metrics/datadog/TaggedNameTest.java
@@ -75,6 +75,33 @@ public class TaggedNameTest {
   }
 
   @Test
+  public void testDecodeTwoTagsDotted() throws Exception {
+    TaggedName tn = TaggedName.decode("my.metric.name[key.1:val.1,key.2]");
+    assertEquals("my.metric.name", tn.getMetricName());
+    assertEquals(2, tn.getEncodedTags().size());
+    assertEquals("key.1:val.1", tn.getEncodedTags().get(0));
+    assertEquals("key.2", tn.getEncodedTags().get(1));
+  }
+
+  @Test
+  public void testDecodeTwoTagsDashed() throws Exception {
+    TaggedName tn = TaggedName.decode("my-metric-name[key-1:val-1,key-2]");
+    assertEquals("my-metric-name", tn.getMetricName());
+    assertEquals(2, tn.getEncodedTags().size());
+    assertEquals("key-1:val-1", tn.getEncodedTags().get(0));
+    assertEquals("key-2", tn.getEncodedTags().get(1));
+  }
+
+  @Test
+  public void testDecodeTwoTagsUnderscored() throws Exception {
+    TaggedName tn = TaggedName.decode("my_metric_name[key_1:val_1,key_2]");
+    assertEquals("my_metric_name", tn.getMetricName());
+    assertEquals(2, tn.getEncodedTags().size());
+    assertEquals("key_1:val_1", tn.getEncodedTags().get(0));
+    assertEquals("key_2", tn.getEncodedTags().get(1));
+  }
+
+  @Test
   public void testDecodeInvalidEncodings() throws Exception {
     // note that parsing could be stricter, but we're relaxing things to
     // maintain backward compatibility with prior parsing logic


### PR DESCRIPTION
Previous code would decode the metric name of input
"my-metric-name[foo:bar]" as "name".  i.e. Everything until after the
last hyphen was thrown out.  This is because `-` isn't part of the `\w`
character class (see TaggedName.java).

Datadog doesn't technically allow hyphens in metric names, however it
does accept metrics names containing hyphens, it's just automatically
replaces them with underscores
(http://docs.datadoghq.com/faq/#api-metric-names)

This patch changes TaggedName to accept hyphens, and adds some tests
around non-alphanumeric characters in metric and tag names.