### PR TITLE
Retrying for volatile host

### DIFF
--- a/dropwizard-metrics-datadog/src/main/java/org/coursera/metrics/datadog/transport/UdpTransportFactory.java
+++ b/dropwizard-metrics-datadog/src/main/java/org/coursera/metrics/datadog/transport/UdpTransportFactory.java
@@ -16,6 +16,9 @@ public class UdpTransportFactory implements AbstractTransportFactory {
   private int port = 8125;
 
   @JsonProperty
+  private boolean retryingLookup = false;
+
+  @JsonProperty
   private String prefix = null;
 
   public UdpTransport build() {
@@ -23,6 +26,7 @@ public class UdpTransportFactory implements AbstractTransportFactory {
         .withPrefix(prefix)
         .withStatsdHost(statsdHost)
         .withPort(port)
+        .withRetryingLookup(retryingLookup)
         .build();
     }
 }

--- a/metrics-datadog/pom.xml
+++ b/metrics-datadog/pom.xml
@@ -47,6 +47,12 @@
             <version>1.7.7</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>com.alibaba</groupId>
+            <artifactId>dns-cache-manipulator</artifactId>
+            <version>1.5.1</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
 </project>

--- a/metrics-datadog/src/main/java/org/coursera/metrics/datadog/transport/UdpTransport.java
+++ b/metrics-datadog/src/main/java/org/coursera/metrics/datadog/transport/UdpTransport.java
@@ -157,8 +157,8 @@ public class UdpTransport implements Transport {
   static Callable<InetSocketAddress> staticAddressResolver(final String host, final int port) {
     try {
       return NonBlockingStatsDClient.staticAddressResolution(host, port);
-    } catch(final Exception e){
-      LOG.error("Error during constructing statsd address resolutor.", e);
+    } catch(final Exception e) {
+      LOG.error("Error during constructing statsd address resolver.", e);
       throw new RuntimeException(e);
     }
   }

--- a/metrics-datadog/src/main/java/org/coursera/metrics/datadog/transport/UdpTransport.java
+++ b/metrics-datadog/src/main/java/org/coursera/metrics/datadog/transport/UdpTransport.java
@@ -9,8 +9,10 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
+import java.net.InetSocketAddress;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.concurrent.Callable;
 
 /**
  * Uses dogstatsd UDP protocol to push metrics to datadog. Note that datadog doesn't support
@@ -27,17 +29,25 @@ public class UdpTransport implements Transport {
   private final StatsDClient statsd;
   private final Map lastSeenCounters = new HashMap<String, Long>();
 
-  private UdpTransport(String prefix, String statsdHost, int port, String[] globalTags) {
+  private UdpTransport(String prefix, String statsdHost, int port, boolean isRetryingLookup, String[] globalTags) {
+    final Callable<InetSocketAddress> socketAddressCallable;
+
+    if(isRetryingLookup) {
+      socketAddressCallable = volatileAddressResolver(statsdHost, port);
+    } else {
+      socketAddressCallable = staticAddressResolver(statsdHost, port);
+    }
+
     statsd = new NonBlockingStatsDClient(
             prefix,
-            statsdHost,
-            port,
+            Integer.MAX_VALUE,
             globalTags,
             new StatsDClientErrorHandler() {
               public void handle(Exception e) {
                 LOG.error(e.getMessage(), e);
               }
-            }
+            },
+            socketAddressCallable
     );
   }
 
@@ -49,6 +59,7 @@ public class UdpTransport implements Transport {
     String prefix = null;
     String statsdHost = "localhost";
     int port = 8125;
+    boolean isLookupRetrying = false;
 
     public Builder withPrefix(String prefix) {
       this.prefix = prefix;
@@ -65,8 +76,13 @@ public class UdpTransport implements Transport {
       return this;
     }
 
+    public Builder withRetryingLookup(boolean isRetrying) {
+      this.isLookupRetrying = isRetrying;
+      return this;
+    }
+
     public UdpTransport build() {
-      return new UdpTransport(prefix, statsdHost, port, new String[0]);
+      return new UdpTransport(prefix, statsdHost, port, isLookupRetrying, new String[0]);
     }
   }
 
@@ -135,5 +151,20 @@ public class UdpTransport implements Transport {
      */
     public void send() {
     }
+  }
+
+  // Visible for testing.
+  static Callable<InetSocketAddress> staticAddressResolver(final String host, final int port) {
+    try {
+      return NonBlockingStatsDClient.staticAddressResolution(host, port);
+    } catch(final Exception e){
+      LOG.error("Error during constructing statsd address resolutor.", e);
+      throw new RuntimeException(e);
+    }
+  }
+
+  // Visible for testing.
+  static Callable<InetSocketAddress> volatileAddressResolver(final String host, final int port) {
+    return NonBlockingStatsDClient.volatileAddressResolution(host, port);
   }
 }

--- a/metrics-datadog/src/test/java/org/coursera/metrics/datadog/transport/UdpTransportTest.java
+++ b/metrics-datadog/src/test/java/org/coursera/metrics/datadog/transport/UdpTransportTest.java
@@ -1,0 +1,58 @@
+package org.coursera.metrics.datadog.transport;
+
+import java.net.InetSocketAddress;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+
+import com.alibaba.dcm.DnsCacheManipulator;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+public class UdpTransportTest {
+  private static final ExecutorService EXECUTOR = Executors.newSingleThreadExecutor();
+  private static final String LOCAL_IP = "127.0.0.1";
+  private static final String TEST_HOST = "fastandunresolvable";
+  private static final int TEST_PORT = 1111;
+
+  @Before
+  public void cleanDnsCache() {
+    DnsCacheManipulator.clearDnsCache();
+  }
+
+  @Test
+  public void constructsWithReachableHost() {
+    DnsCacheManipulator.setDnsCache(TEST_HOST, LOCAL_IP);
+
+    final UdpTransport transport = new UdpTransport.Builder().withStatsdHost(TEST_HOST).build();
+    assertNotNull(transport);
+  }
+
+  @Test
+  public void constructsWhenUnreachableHostWithRetry() {
+    assertNotNull(new UdpTransport.Builder().withStatsdHost(TEST_HOST).withRetryingLookup(true).build());
+  }
+
+  @Test(expected = RuntimeException.class)
+  public void throwsWhenUnreachableHost() {
+    new UdpTransport.Builder().withStatsdHost(TEST_HOST).build();
+  }
+
+  @Test
+  public void volatileResolverResolvesByTheTimeTheHostIsResolvable() throws Exception {
+    final Callable<InetSocketAddress> retryingCallable = UdpTransport.volatileAddressResolver(TEST_HOST, TEST_PORT);
+    // ^ Doesn't crash when host is unresolvable.
+
+    try {
+      retryingCallable.call();
+      assertFalse(true);
+    } catch (final Exception e) {}
+    // ^ This should throw becuase the host is unresolvable.
+
+    DnsCacheManipulator.setDnsCache(TEST_HOST, LOCAL_IP); // Make host resolvable.
+    assertNotNull(retryingCallable.call()); // Returns with resolved by the time it's resolvable.
+  }
+}


### PR DESCRIPTION
Hi Guys n Gals!

First of all: thanks for putting work into this project, we found it `supa-dupa-handy`! :)

We found a little "bug" in it which caused some of the services to miss reporting, it was triggered by some DNS trouble on our side, which caused the metrics to fail, this PR is a proposal for fixing these scenarios, please see below.

**Problem**

By default [NonBlockingStatsDClient's constructor](https://github.com/DataDog/java-dogstatsd-client/blob/master/src/main/java/com/timgroup/statsd/NonBlockingStatsDClient.java#L229) uses  [staticStatsDAddressResolution](https://github.com/DataDog/java-dogstatsd-client/blob/master/src/main/java/com/timgroup/statsd/NonBlockingStatsDClient.java#L937) which resolves the host only once at the beginning.

This is a good choice!
This surely spares a lot of extra work thorough the lifecycle of a service, as a side effect, if the host is not resolvable at the time of construction it'll cause reporting to fail.

**How one may avoid it?**

I've added an extra `retrying_lookup` option to the configuration for `UdpTransport`, which defaults to false, in that setting everything works as before, when set to true it'll use [volatileAddressResolution](https://github.com/DataDog/java-dogstatsd-client/blob/master/src/main/java/com/timgroup/statsd/NonBlockingStatsDClient.java#L912) for resolving addresses.

`volatileAddressResolution` will do a lookup each time it's called (cache is provided by [InetAddress](http://docs.oracle.com/javase/8/docs/api/java/net/InetAddress.html)), allowing the host to be resolved later, when it's possible to do so.

---

Let me know what you think!

Thanks!
Reg,
-Dan