### PR TITLE
Split logging of POST body from logging of URL, add body length

### DIFF
--- a/metrics-datadog/src/main/java/org/coursera/metrics/datadog/transport/HttpTransport.java
+++ b/metrics-datadog/src/main/java/org/coursera/metrics/datadog/transport/HttpTransport.java
@@ -116,9 +116,13 @@ public class HttpTransport implements Transport {
         StringBuilder sb = new StringBuilder();
         sb.append("Sending HTTP POST request to ");
         sb.append(this.transport.seriesUrl);
-        sb.append(", POST body is: \n");
-        sb.append(postBody);
+        sb.append(", POST body length is: ");
+        sb.append(postBody.length());
         LOG.debug(sb.toString());
+
+        StringBuilder bodyMsgBuilder = new StringBuilder();
+        bodyMsgBuilder.append("POST body is: \n").append(postBody);
+        LOG.debug(bodyMsgBuilder.toString());
       }
       long start = System.currentTimeMillis();
       org.apache.http.client.fluent.Request request = Post(this.transport.seriesUrl)


### PR DESCRIPTION
I was running into the problem that the post body was too big, DD has a
limit of 3MB, above which the request will be rejected. Therefore, in
order to easily monitor the current request size, I added the length of
the request body string.

Additionally, a very long request body led to log messages not being
recorded by the ELK stack I use. So in order for having the request
sizes logged even when a very long request body leads to broken logging,
I split the body from the rest and logged them separately.