### PR TITLE
HttpTransport: Compress POST body

### DIFF
--- a/metrics-datadog/src/main/java/org/coursera/metrics/datadog/transport/HttpTransport.java
+++ b/metrics-datadog/src/main/java/org/coursera/metrics/datadog/transport/HttpTransport.java
@@ -39,7 +39,12 @@ public class HttpTransport implements Transport {
   private final Executor executor;
   private final boolean useCompression;
 
-  private HttpTransport(String apiKey, int connectTimeout, int socketTimeout, HttpHost proxy, Executor executor, boolean useCompression) {
+  private HttpTransport(String apiKey,
+                        int connectTimeout,
+                        int socketTimeout,
+                        HttpHost proxy,
+                        Executor executor,
+                        boolean useCompression) {
     this.seriesUrl = String.format("%s/series?api_key=%s", BASE_URL, apiKey);
     this.connectTimeout = connectTimeout;
     this.socketTimeout = socketTimeout;
@@ -141,13 +146,15 @@ public class HttpTransport implements Transport {
         .useExpectContinue()
         .connectTimeout(this.transport.connectTimeout)
         .socketTimeout(this.transport.socketTimeout);
-        if (this.transport.useCompression) {
-          request.addHeader("Content-Encoding", "deflate")
-            .addHeader("Content-MD5", DigestUtils.md5Hex(postBody))
-            .bodyStream(deflated(postBody), ContentType.APPLICATION_JSON);
-        } else {
-          request.bodyString(postBody, ContentType.APPLICATION_JSON);
-        }
+
+      if (this.transport.useCompression) {
+        request
+          .addHeader("Content-Encoding", "deflate")
+          .addHeader("Content-MD5", DigestUtils.md5Hex(postBody))
+          .bodyStream(deflated(postBody), ContentType.APPLICATION_JSON);
+      } else {
+        request.bodyString(postBody, ContentType.APPLICATION_JSON);
+      }
 
       if (this.transport.proxy != null) {
         request.viaProxy(this.transport.proxy);

--- a/metrics-datadog/src/main/java/org/coursera/metrics/datadog/transport/HttpTransport.java
+++ b/metrics-datadog/src/main/java/org/coursera/metrics/datadog/transport/HttpTransport.java
@@ -175,6 +175,7 @@ public class HttpTransport implements Transport {
             StringBuilder sb = new StringBuilder();
 
             sb.append(headline);
+            sb.append("\n");
             sb.append("  Timing: ").append(elapsed).append(" ms\n");
             sb.append("  Status: ").append(response.getStatusLine().getStatusCode()).append("\n");
 

--- a/pom.xml
+++ b/pom.xml
@@ -65,8 +65,8 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>2.3.1</version>
                 <configuration>
-                    <source>1.5</source>
-                    <target>1.5</target>
+                    <source>1.6</source>
+                    <target>1.6</target>
                 </configuration>
             </plugin>
             <plugin>


### PR DESCRIPTION
I recently ran into the 3MB limit on DDs API for posting metrics. They told me
that their API allows for a compressed payload (see
https://github.com/DataDog/dd-agent/blob/00bed41fa3c64824098761b1522c91cdfda43e65/emitter.py#L102).

This commit adds compression analogous to the dd-agent python
implementation referenced above.

In order to be able to use DeflaterInputStream, source and target
java versions have been bumped to 1.6