### PR TITLE
Fixed metricNameFormatter example yml configuration format in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -227,7 +227,8 @@ Datadog tags but does not modify the metric name.
 metrics:
   reporters:
     - type: datadog
-      metricNameFormatter: custom
+      metricNameFormatter:
+        type: custom
 ~~~
 
 Adding a custom formatter requires a few things:


### PR DESCRIPTION
The previous example causes: "Failed to parse configuration at: metrics.reporters.metricNameFormatter; Unexpected token (VALUE_STRING), expected FIELD_NAME: missing property 'type' that is to contain type id (for class org.coursera.metrics.datadog.MetricNameFormatterFactory)"