### PR TITLE
Bump versions

### DIFF
--- a/metrics-datadog/pom.xml
+++ b/metrics-datadog/pom.xml
@@ -44,7 +44,6 @@
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-simple</artifactId>
-            <version>1.7.7</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -54,7 +54,7 @@
         </contributor>
     </contributors>
     <properties>
-        <metrics.version>3.1.1</metrics.version>
+        <metrics.version>4.0.1</metrics.version>
         <jackson.version>2.9.3</jackson.version>
         <dropwizard.version>1.2.2</dropwizard.version>
     </properties>

--- a/pom.xml
+++ b/pom.xml
@@ -56,7 +56,7 @@
     <properties>
         <metrics.version>3.1.1</metrics.version>
         <jackson.version>2.9.3</jackson.version>
-        <dropwizard.version>0.9.1</dropwizard.version>
+        <dropwizard.version>1.2.2</dropwizard.version>
     </properties>
     <build>
         <plugins>
@@ -65,8 +65,8 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>3.7.0</version>
                 <configuration>
-                    <source>1.6</source>
-                    <target>1.6</target>
+                    <source>1.8</source>
+                    <target>1.8</target>
                 </configuration>
             </plugin>
             <plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -63,7 +63,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>2.3.1</version>
+                <version>3.7.0</version>
                 <configuration>
                     <source>1.6</source>
                     <target>1.6</target>
@@ -72,12 +72,12 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-deploy-plugin</artifactId>
-                <version>2.7</version>
+                <version>2.8.2</version>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-source-plugin</artifactId>
-                <version>2.3</version>
+                <version>3.0.1</version>
                 <executions>
                     <execution>
                         <id>attach-sources</id>
@@ -90,7 +90,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-javadoc-plugin</artifactId>
-                <version>2.10.1</version>
+                <version>2.10.4</version>
                 <executions>
                     <execution>
                         <id>attach-javadocs</id>
@@ -106,7 +106,7 @@
             <plugin>
                 <groupId>org.sonatype.plugins</groupId>
                 <artifactId>nexus-staging-maven-plugin</artifactId>
-                <version>1.6.3</version>
+                <version>1.6.8</version>
                 <extensions>true</extensions>
                 <configuration>
                     <serverId>ossrh</serverId>
@@ -117,7 +117,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-gpg-plugin</artifactId>
-                <version>1.5</version>
+                <version>1.6</version>
                 <executions>
                     <execution>
                         <id>sign-artifacts</id>

--- a/pom.xml
+++ b/pom.xml
@@ -158,7 +158,7 @@
             <dependency>
                 <groupId>com.datadoghq</groupId>
                 <artifactId>java-dogstatsd-client</artifactId>
-                <version>2.3</version>
+                <version>2.4</version>
             </dependency>
             <dependency>
                 <groupId>junit</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -55,7 +55,7 @@
     </contributors>
     <properties>
         <metrics.version>3.1.1</metrics.version>
-        <jackson.version>2.4.2</jackson.version>
+        <jackson.version>2.9.3</jackson.version>
         <dropwizard.version>0.9.1</dropwizard.version>
     </properties>
     <build>
@@ -148,7 +148,7 @@
             <dependency>
                 <groupId>org.apache.httpcomponents</groupId>
                 <artifactId>fluent-hc</artifactId>
-                <version>4.3.6</version>
+                <version>4.5.4</version>
             </dependency>
             <dependency>
                 <groupId>com.fasterxml.jackson.core</groupId>
@@ -163,7 +163,7 @@
             <dependency>
                 <groupId>junit</groupId>
                 <artifactId>junit</artifactId>
-                <version>4.10</version>
+                <version>4.12</version>
                 <scope>test</scope>
             </dependency>
             <dependency>
@@ -175,13 +175,13 @@
             <dependency>
                 <groupId>org.mockito</groupId>
                 <artifactId>mockito-all</artifactId>
-                <version>1.9.5</version>
+                <version>1.10.19</version>
                 <scope>test</scope>
             </dependency>
             <dependency>
                 <groupId>org.slf4j</groupId>
                 <artifactId>slf4j-simple</artifactId>
-                <version>1.7.7</version>
+                <version>1.7.25</version>
                 <scope>test</scope>
             </dependency>
         </dependencies>


### PR DESCRIPTION
Will fix #88, also updated all dependencies to their latest versions.
Tested only with `mvn clean package`, you may have surprises during deployment. 

**Note that Java 1.8 is now required** 

Bumping the project version to `2.0.0` or `1.2.0` is therefore recommended. 