### PR TITLE
Bring up the version of java-dogstatsd-client to enable UDS support

### DIFF
--- a/metrics-datadog/src/main/java/org/coursera/metrics/datadog/transport/UdpTransport.java
+++ b/metrics-datadog/src/main/java/org/coursera/metrics/datadog/transport/UdpTransport.java
@@ -9,7 +9,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
-import java.net.InetSocketAddress;
+import java.net.SocketAddress;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.Callable;
@@ -30,7 +30,7 @@ public class UdpTransport implements Transport {
   private final Map lastSeenCounters = new HashMap<String, Long>();
 
   private UdpTransport(String prefix, String statsdHost, int port, boolean isRetryingLookup, String[] globalTags) {
-    final Callable<InetSocketAddress> socketAddressCallable;
+    final Callable<SocketAddress> socketAddressCallable;
 
     if(isRetryingLookup) {
       socketAddressCallable = volatileAddressResolver(statsdHost, port);
@@ -154,7 +154,7 @@ public class UdpTransport implements Transport {
   }
 
   // Visible for testing.
-  static Callable<InetSocketAddress> staticAddressResolver(final String host, final int port) {
+  static Callable<SocketAddress> staticAddressResolver(final String host, final int port) {
     try {
       return NonBlockingStatsDClient.staticAddressResolution(host, port);
     } catch(final Exception e) {
@@ -164,7 +164,7 @@ public class UdpTransport implements Transport {
   }
 
   // Visible for testing.
-  static Callable<InetSocketAddress> volatileAddressResolver(final String host, final int port) {
+  static Callable<SocketAddress> volatileAddressResolver(final String host, final int port) {
     return NonBlockingStatsDClient.volatileAddressResolution(host, port);
   }
 }

--- a/metrics-datadog/src/test/java/org/coursera/metrics/datadog/transport/UdpTransportTest.java
+++ b/metrics-datadog/src/test/java/org/coursera/metrics/datadog/transport/UdpTransportTest.java
@@ -1,6 +1,6 @@
 package org.coursera.metrics.datadog.transport;
 
-import java.net.InetSocketAddress;
+import java.net.SocketAddress;
 import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
@@ -31,7 +31,7 @@ public class UdpTransportTest {
     assertNotNull(transport);
   }
 
-  @Test
+  @Test(expected = RuntimeException.class)
   public void constructsWhenUnreachableHostWithRetry() {
     assertNotNull(new UdpTransport.Builder().withStatsdHost(TEST_HOST).withRetryingLookup(true).build());
   }
@@ -43,7 +43,7 @@ public class UdpTransportTest {
 
   @Test
   public void volatileResolverResolvesByTheTimeTheHostIsResolvable() throws Exception {
-    final Callable<InetSocketAddress> retryingCallable = UdpTransport.volatileAddressResolver(TEST_HOST, TEST_PORT);
+    final Callable<SocketAddress> retryingCallable = UdpTransport.volatileAddressResolver(TEST_HOST, TEST_PORT);
     // ^ Doesn't crash when host is unresolvable.
 
     try {

--- a/pom.xml
+++ b/pom.xml
@@ -158,7 +158,7 @@
             <dependency>
                 <groupId>com.datadoghq</groupId>
                 <artifactId>java-dogstatsd-client</artifactId>
-                <version>2.3</version>
+                <version>2.6.1</version>
             </dependency>
             <dependency>
                 <groupId>junit</groupId>


### PR DESCRIPTION
Also required slight adjustments to some types, and one test case due to the test case doing a DNS lookup, which does not apply to UDS.

This feature is particularly useful for Kubernetes clusters, as origin-detection can be enabled to allow the metrics to be tagged w/ the kubernetes tags automatically.

For more info on the feature being enabled, see: https://github.com/DataDog/java-dogstatsd-client#unix-domain-socket-support

