### PR TITLE
Report Guage Values of type Boolean as 1/0

### DIFF
--- a/metrics-datadog/src/main/java/org/coursera/metrics/datadog/DatadogReporter.java
+++ b/metrics-datadog/src/main/java/org/coursera/metrics/datadog/DatadogReporter.java
@@ -222,6 +222,8 @@ public class DatadogReporter extends ScheduledReporter {
   private Number toNumber(Object o) {
     if (o instanceof Number) {
       return (Number) o;
+    } else if (o instanceof Boolean) {
+      return ((Boolean) o) ? 1 : 0;
     }
     return null;
   }

--- a/metrics-datadog/src/test/java/org/coursera/metrics/datadog/DatadogReporterTest.java
+++ b/metrics-datadog/src/test/java/org/coursera/metrics/datadog/DatadogReporterTest.java
@@ -153,6 +153,17 @@ public class DatadogReporterTest {
   }
 
   @Test
+  public void reportsBooleanGaugeValues() throws Exception {
+    reporter.report(map("gauge", gauge(true)),
+            this.<Counter>map(),
+            this.<Histogram>map(),
+            this.<Meter>map(),
+            this.<Timer>map());
+
+    gaugeTestHelper("gauge", 1, timestamp, HOST, tags);
+  }
+
+  @Test
   public void reportHandlesGaugeMetricExceptions() throws Exception {
     final Gauge gauge = mock(Gauge.class);
     when(gauge.getValue()).thenThrow(new IllegalArgumentException("error occurred during retrieving value"));


### PR DESCRIPTION
When exporting metrics from hystrix to graphite (https://github.com/Netflix/Hystrix using https://github.com/Netflix/Hystrix/tree/master/hystrix-contrib/hystrix-codahale-metrics-publisher) any Boolean values like  isCircuitBreakerOpen that are not exported to Datadog.