### PR TITLE
Allow tag values which contain delimiter

### DIFF
--- a/metrics-datadog/src/main/java/org/coursera/metrics/datadog/TagUtils.java
+++ b/metrics-datadog/src/main/java/org/coursera/metrics/datadog/TagUtils.java
@@ -33,11 +33,15 @@ class TagUtils {
 
     Map<String, String> map = new HashMap<String, String>();
     for (String tag : newTags) {
-      String[] strs = tag.split(":");
-      if (strs.length != 2) {
+
+      int delimiterIndex = tag.indexOf(":");
+      int tagLength = tag.length();
+      if (tagLength < 1 || delimiterIndex <= 0 || delimiterIndex == tagLength - 1) {
         LOG.warn("Invalid tag: " + tag);
       } else {
-        map.put(strs[0], strs[1]);
+        String key = tag.substring(0, delimiterIndex);
+        String value = tag.substring(delimiterIndex + 1);
+        map.put(key, value);
       }
     }
 

--- a/metrics-datadog/src/test/java/org/coursera/metrics/datadog/TagUtilsTest.java
+++ b/metrics-datadog/src/test/java/org/coursera/metrics/datadog/TagUtilsTest.java
@@ -42,4 +42,62 @@ public class TagUtilsTest {
     assert(new TreeSet<String>(TagUtils.mergeTags(tags1, tags2)).equals(
             new TreeSet<String>(expected)));
   }
+
+  @Test
+  public void mergeTagsWithMultipleDelimiters() throws Exception {
+    List<String> tags1 = new ArrayList<String>();
+    tags1.add("key1:value_with_:_in_the_middle");
+    List<String> tags2 = new ArrayList<String>();
+    tags2.add("key2:value");
+
+
+    List<String> expected = new ArrayList<String>();
+    expected.addAll(tags1);
+    expected.addAll(tags2);
+    assert(new TreeSet<String>(TagUtils.mergeTags(tags1, tags2)).equals(
+            new TreeSet<String>(expected)));
+  }
+
+
+  @Test
+  public void mergeTagsWithNoValue() throws Exception {
+    List<String> tags1 = new ArrayList<String>();
+    tags1.add("no_value:");
+    List<String> tags2 = new ArrayList<String>();
+    tags2.add("key:value");
+
+
+    List<String> expected = new ArrayList<String>();
+    expected.addAll(tags2);
+    assert(new TreeSet<String>(TagUtils.mergeTags(tags1, tags2)).equals(
+            new TreeSet<String>(expected)));
+  }
+
+  @Test
+  public void mergeTagsWithNoKey() throws Exception {
+    List<String> tags1 = new ArrayList<String>();
+    tags1.add(":value");
+    List<String> tags2 = new ArrayList<String>();
+    tags2.add("key:value");
+
+
+    List<String> expected = new ArrayList<String>();
+    expected.addAll(tags2);
+    assert(new TreeSet<String>(TagUtils.mergeTags(tags1, tags2)).equals(
+            new TreeSet<String>(expected)));
+  }
+
+  @Test
+  public void mergeTagsWithNoDelimiter() throws Exception {
+    List<String> tags1 = new ArrayList<String>();
+    tags1.add("discouraged_value");
+    List<String> tags2 = new ArrayList<String>();
+    tags2.add("key:value");
+
+
+    List<String> expected = new ArrayList<String>();
+    expected.addAll(tags2);
+    assert(new TreeSet<String>(TagUtils.mergeTags(tags1, tags2)).equals(
+            new TreeSet<String>(expected)));
+  }
 }


### PR DESCRIPTION
According to Datadog documentation a key:value which contains a value where a ':' resides
is a legal value. Datadog splits on the first ':'. Added logic to allow for this in TagUtils.
I also added unit tests and negative tests.

![image](https://user-images.githubusercontent.com/6953661/56702995-7abbcb80-66cc-11e9-8451-086ea15e55bb.png)

See also:
https://docs.datadoghq.com/tagging/

