### PR TITLE
expose new params for java-dogstatsd-client for socket/packets

### DIFF
--- a/dropwizard-metrics-datadog/pom.xml
+++ b/dropwizard-metrics-datadog/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>metrics-datadog-parent</artifactId>
         <groupId>org.coursera</groupId>
-        <version>2.0.0-RC1</version>
+        <version>2.0.0-RC2</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/metrics-datadog/pom.xml
+++ b/metrics-datadog/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.coursera</groupId>
         <artifactId>metrics-datadog-parent</artifactId>
-        <version>2.0.0-RC1</version>
+        <version>2.0.0-RC2</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/metrics-datadog/src/main/java/org/coursera/metrics/datadog/transport/UdpTransport.java
+++ b/metrics-datadog/src/main/java/org/coursera/metrics/datadog/transport/UdpTransport.java
@@ -29,7 +29,7 @@ public class UdpTransport implements Transport {
   private final StatsDClient statsd;
   private final Map lastSeenCounters = new HashMap<String, Long>();
 
-  private UdpTransport(String prefix, String statsdHost, int port, boolean isRetryingLookup, String[] globalTags) {
+  private UdpTransport(String prefix, String statsdHost, int port, boolean isRetryingLookup, String[] globalTags, int socketTimeoutMs, int socketBufferBytes, int maxPacketSizeBytes) {
     final Callable<SocketAddress> socketAddressCallable;
 
     if(isRetryingLookup) {
@@ -47,7 +47,10 @@ public class UdpTransport implements Transport {
                 LOG.error(e.getMessage(), e);
               }
             },
-            socketAddressCallable
+            socketAddressCallable,
+	    socketTimeoutMs,
+	    socketBufferBytes,
+	    maxPacketSizeBytes
     );
   }
 
@@ -60,6 +63,9 @@ public class UdpTransport implements Transport {
     String statsdHost = "localhost";
     int port = 8125;
     boolean isLookupRetrying = false;
+    int socketTimeoutMs = 100;
+    int socketBufferBytes = -1;
+    int maxPacketSizeBytes = 1400;
 
     public Builder withPrefix(String prefix) {
       this.prefix = prefix;
@@ -81,8 +87,23 @@ public class UdpTransport implements Transport {
       return this;
     }
 
+    public Builder withSocketTimeoutMs(int socketTimeoutMs) {
+      this.socketTimeoutMs = socketTimeoutMs;
+      return this;
+    }
+
+    public Builder withSocketBufferBytes(int socketBufferBytes) {
+      this.socketBufferBytes = socketBufferBytes;
+      return this;
+    }
+
+    public Builder withMaxPacketSizeBytes (int maxPacketSizeBytes) {
+      this.maxPacketSizeBytes = maxPacketSizeBytes;
+      return this;
+    }
+
     public UdpTransport build() {
-      return new UdpTransport(prefix, statsdHost, port, isLookupRetrying, new String[0]);
+      return new UdpTransport(prefix, statsdHost, port, isLookupRetrying, new String[0], socketTimeoutMs, socketBufferBytes, maxPacketSizeBytes);
     }
   }
 

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.coursera</groupId>
     <artifactId>metrics-datadog-parent</artifactId>
-    <version>2.0.0-RC1</version>
+    <version>2.0.0-RC2</version>
     <packaging>pom</packaging>
     <name>Datadog Metrics Parent</name>
     <url>https://github.com/coursera/metrics-datadog</url>
@@ -159,7 +159,7 @@
             <dependency>
                 <groupId>com.datadoghq</groupId>
                 <artifactId>java-dogstatsd-client</artifactId>
-                <version>2.6.1</version>
+                <version>2.8</version>
             </dependency>
             <dependency>
                 <groupId>junit</groupId>


### PR DESCRIPTION
This updates the integration to use a newer version of java-dogstatsd-client, and exposes a few new tunables relating to UDP/UDS socket timeout, buffer size, and packet size, for use by callers.

I've also taken the liberty of bumping versions to 2.0.0-RC2

Signed-off-by: Joe Hohertz <joe@viafoura.com>