### PR TITLE
Update metric submission end point

### DIFF
--- a/metrics-datadog/src/main/java/org/coursera/metrics/datadog/transport/HttpTransport.java
+++ b/metrics-datadog/src/main/java/org/coursera/metrics/datadog/transport/HttpTransport.java
@@ -31,7 +31,7 @@ public class HttpTransport implements Transport {
 
   private static final Logger LOG = LoggerFactory.getLogger(HttpTransport.class);
 
-  private final static String BASE_URL = "https://app.datadoghq.com/api/v1";
+  private final static String BASE_URL = "https://api.datadoghq.com/api/v1";
   private final String seriesUrl;
   private final int connectTimeout;     // in milliseconds
   private final int socketTimeout;      // in milliseconds


### PR DESCRIPTION
api.datadoghq.com is Datadog's preferred submission end point for metrics. app.datadoghq.com will continue to work but does not offer a number of newer capabilities.