### PR TITLE
Updated Dropwizard and Jackson dependency versions

### DIFF
--- a/dropwizard-metrics-datadog/pom.xml
+++ b/dropwizard-metrics-datadog/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>metrics-datadog-parent</artifactId>
         <groupId>org.coursera</groupId>
-        <version>2.0.0-RC1</version>
+        <version>2.0.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/metrics-datadog/pom.xml
+++ b/metrics-datadog/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.coursera</groupId>
         <artifactId>metrics-datadog-parent</artifactId>
-        <version>2.0.0-RC1</version>
+        <version>2.0.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.coursera</groupId>
     <artifactId>metrics-datadog-parent</artifactId>
-    <version>2.0.0-RC1</version>
+    <version>2.0.0-SNAPSHOT</version>
     <packaging>pom</packaging>
     <name>Datadog Metrics Parent</name>
     <url>https://github.com/coursera/metrics-datadog</url>
@@ -55,9 +55,9 @@
         </contributor>
     </contributors>
     <properties>
-        <metrics.version>4.0.2</metrics.version>
-        <jackson.version>2.9.6</jackson.version>
-        <dropwizard.version>1.3.4</dropwizard.version>
+        <metrics.version>4.1.18</metrics.version>
+        <jackson.version>2.12.2</jackson.version>
+        <dropwizard.version>1.3.29</dropwizard.version>
     </properties>
     <build>
         <plugins>


### PR DESCRIPTION
This was done to address High Severity CVEs:

* Dropwizard - https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2020-11002
* Jackson - Several, including https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2020-35490